### PR TITLE
Added check of exit status for `new`

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -8,7 +8,8 @@ function check_new() {
     ln -s ./target/debug/amethyst .
     ./amethyst new mygame
 
-    if [ -f mygame/Cargo.toml ] &&
+    if [ $? -eq 0 ] &&
+       [ -f mygame/Cargo.toml ] &&
        [ -d mygame/resources/entities/ ] &&
        [ -d mygame/resources/prefabs/ ] &&
        [ -f mygame/resources/config.yml ] &&


### PR DESCRIPTION
Previously tests.sh didn't check if `amethyst new` exited successfully, this is why #12 was passing on CI.
