### PR TITLE
Expose cargo failures

### DIFF
--- a/src/cli/cargo.rs
+++ b/src/cli/cargo.rs
@@ -15,14 +15,13 @@ pub fn call(args: Vec<&str>) -> Option<&'static str> {
                                .stderr(Stdio::inherit())
                                .output();
 
-    match output_result {
-        Ok(output) => {
-            if output.status.success() {
-                None
-            } else {
-                Some("Cargo task failed!")
-            }
+    if let Ok(output) = output_result {
+        if output.status.success() {
+            None
+        } else {
+            Some("Cargo task failed!")
         }
-        Err(_) => Some("Failed to run Cargo!"),
+    } else {
+        Some("Failed to run Cargo!")
     }
 }

--- a/src/cli/cargo.rs
+++ b/src/cli/cargo.rs
@@ -11,13 +11,18 @@ pub fn call(args: Vec<&str>) -> Option<&'static str> {
         command.arg(arg);
     }
 
-    let output = command.stdout(Stdio::inherit())
-                        .stderr(Stdio::inherit())
-                        .output()
-                        .ok();
+    let output_result = command.stdout(Stdio::inherit())
+                               .stderr(Stdio::inherit())
+                               .output();
 
-    match output {
-        Some(_) => None,
-        None => Some("Failed to run Cargo!"),
+    match output_result {
+        Ok(output) => {
+            if output.status.success() {
+                None
+            } else {
+                Some("Cargo task failed!")
+            }
+        }
+        Err(_) => Some("Failed to run Cargo!"),
     }
 }

--- a/tests.sh
+++ b/tests.sh
@@ -80,7 +80,7 @@ function check_bad_build() {
 
     if [ $? -ne 0 ]; then
         echo "--- Passed!"
-	echo
+        echo
         return
     fi
 

--- a/tests.sh
+++ b/tests.sh
@@ -71,10 +71,28 @@ function check_clean() {
     exit 1
 }
 
+function check_bad_build() {
+    echo "--- amethyst build"
+
+    cd mygame
+    rm -rf src
+    ../amethyst build
+
+    if [ $? -ne 0 ]; then
+        echo "--- Passed!"
+	echo
+        return
+    fi
+
+    ls -l
+    exit 1
+}
+
 check_new
 check_build
 check_run
 check_clean
+check_bad_build
 
 echo
 echo "All tests pass!"


### PR DESCRIPTION
`cargo::call` properly returns `Some()` (I still think it should be `Result` instead of `Option`) if cargo task has failed (exited with non-zero status).
