### PR TITLE
Added Support for --release flag

### DIFF
--- a/src/cli/subcmds/build.rs
+++ b/src/cli/subcmds/build.rs
@@ -5,6 +5,12 @@ use clap::ArgMatches;
 use cargo;
 
 /// Compiles the current Amethyst project.
-pub fn execute(_matches: &ArgMatches) -> cargo::CmdResult {
-    cargo::call(vec!["build", "--color=always"])
+pub fn execute(matches: &ArgMatches) -> cargo::CmdResult {
+    let mut args = vec!["build", "--color=always"];
+
+    if matches.is_present("release") {
+        args.push("--release");
+    }
+
+    cargo::call(args)
 }

--- a/src/cli/subcmds/clean.rs
+++ b/src/cli/subcmds/clean.rs
@@ -5,6 +5,12 @@ use clap::ArgMatches;
 use cargo;
 
 /// Removes the target directory.
-pub fn execute(_matches: &ArgMatches) -> cargo::CmdResult {
-    cargo::call(vec!["clean", "--color=always"])
+pub fn execute(matches: &ArgMatches) -> cargo::CmdResult {
+    let mut args = vec!["clean", "--color=always"];
+
+    if matches.is_present("release") {
+        args.push("--release");
+    }
+
+    cargo::call(args)
 }

--- a/src/cli/subcmds/run.rs
+++ b/src/cli/subcmds/run.rs
@@ -5,6 +5,12 @@ use clap::ArgMatches;
 use cargo;
 
 /// Builds and executes the application.
-pub fn execute(_matches: &ArgMatches) -> cargo::CmdResult {
-    cargo::call(vec!["run", "--color=always"])
+pub fn execute(matches: &ArgMatches) -> cargo::CmdResult {
+    let mut args = vec!["run", "--color=always"];
+
+    if matches.is_present("release") {
+        args.push("--release");
+    }
+
+    cargo::call(args)
 }

--- a/tests.sh
+++ b/tests.sh
@@ -66,7 +66,19 @@ function check_run() {
     if [ $? -eq 0 ]; then
         echo "--- Passed!"
 	echo
-        return
+    else
+	ls -la
+	exit 1
+    fi
+
+    echo "--- amethyst run --release"
+
+    ../amethyst run --release
+
+    if [ $? -eq 0 ]; then
+	echo "--- Passed!"
+	echo
+	return
     fi
 
     ls -l

--- a/tests.sh
+++ b/tests.sh
@@ -33,9 +33,25 @@ function check_build() {
     ../amethyst build
 
     if [ $? -eq 0 ]; then
-        echo "--- Passed!"
-	echo
-        return
+	if [ -d "target/debug" ]; then
+            echo "--- Passed!"
+	    echo
+	fi
+    else
+	ls -l
+	exit 1
+    fi
+
+    echo "--- amethyst build --release"
+    ../amethyst build --release
+
+    # TODO: check if build actually was ran in release mode
+    if [ $? -eq 0 ]; then
+	if [ -d "target/release" ] ; then
+	   echo "-- Passed!"
+	   echo
+	   return
+	fi
     fi
 
     ls -l
@@ -89,6 +105,10 @@ function check_corrupt_build() {
     exit 1
 }
 
+function clean_up() {
+    rm -r amethyst mygame
+}
+
 check_new
 check_build
 check_run
@@ -98,4 +118,4 @@ check_corrupt_build
 echo
 echo "All tests pass!"
 cd ..
-rm -r amethyst mygame
+clean_up


### PR DESCRIPTION
This PR resolves issue #19. I also believe that there was a typo in that issue because `cargo new` does not support the `--release` flag.

This PR now allows amethyst_cli's subcommands `build`, `run`, and `clean` to support and pass the `--release` flag to cargo. I also wrote tests for `build --release` and `run --release`.
