### PR TITLE
Deploy subcommand for CLI tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ path = "src/cli/main.rs"
 [dependencies]
 clap = "1.5.5"
 zip = { version = "0.1.15", default-features = false }
+walkdir = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ path = "src/cli/main.rs"
 clap = "1.5.5"
 zip = { version = "0.1.15", default-features = false }
 walkdir = "0.1"
+toml = "0.1"

--- a/src/cli/cargo.rs
+++ b/src/cli/cargo.rs
@@ -2,6 +2,12 @@
 
 pub type CmdResult = Result<(), &'static str>;
 
+/// try! macro that handles functions that return results containing non string containing Errors. Primarily std::io::Error
+// FIXME change println! and stringify! to format! or other way of getting the error string
+macro_rules! tryio {
+     ($e:expr) => (match $e { Ok(_) => (), Err(e) => { println!("{}", e); return Err(&stringify!(e)); }})
+}
+
 /// Executes Cargo with the provided arguments. Returns a failure string if
 /// Cargo couldn't be run.
 pub fn call(args: Vec<&str>) -> CmdResult {

--- a/src/cli/cargo.rs
+++ b/src/cli/cargo.rs
@@ -14,8 +14,11 @@ pub enum CmdError {
 
 impl fmt::Display for CmdError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // TODO: find better way to display error
-        write!(f, "[CmdError] {:?}", self)
+        if let &CmdError::Err(ref err) = self {
+            write!(f, "[CmdError] {}", err)
+        } else {
+            write!(f, "[CmdError] {:?}", self)
+        }
     }
 }
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -65,8 +65,8 @@ fn main() {
         (@subcommand test =>
             (about: "Executes all unit and integration tests for the current project"))
         (@subcommand deploy =>
-            (about: "Compresses and deploys the project as a distributable program"))
-            // TODO add argument to force clean before build
+            (about: "Compresses and deploys the project as a distributable program")
+            (@arg clean: --clean "Whether or not to clean before building"))
         (@subcommand module =>
             (about: "Adds or removes engine subsystems"))
         (@subcommand new =>

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -7,6 +7,7 @@
 #[macro_use]
 extern crate clap;
 extern crate zip;
+extern crate walkdir;
 
 #[macro_use]
 mod cargo;

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -8,6 +8,7 @@
 extern crate clap;
 extern crate zip;
 extern crate walkdir;
+extern crate toml;
 
 #[macro_use]
 mod cargo;

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -8,6 +8,7 @@
 extern crate clap;
 extern crate zip;
 
+#[macro_use]
 mod cargo;
 mod subcmds;
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -58,6 +58,8 @@ fn main() {
         (@subcommand clean =>
             (about: "Removes the target directory")
             (@arg release: --release "Whether or not to clean release artifacts"))
+        (@subcommand test =>
+            (about: "Executes all unit and integration tests for the current project"))
         (@subcommand deploy =>
             (about: "Compresses and deploys the project as a distributable program"))
         (@subcommand module =>
@@ -72,6 +74,7 @@ fn main() {
 
     execute_if!(matches, build);
     execute_if!(matches, clean);
+    execute_if!(matches, test);
     execute_if!(matches, deploy);
     execute_if!(matches, module);
     execute_if!(matches, new);

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -63,6 +63,7 @@ fn main() {
             (about: "Executes all unit and integration tests for the current project"))
         (@subcommand deploy =>
             (about: "Compresses and deploys the project as a distributable program"))
+            // TODO add argument to force clean before build
         (@subcommand module =>
             (about: "Adds or removes engine subsystems"))
         (@subcommand new =>

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -5,10 +5,11 @@ use clap::ArgMatches;
 use cargo;
 
 use std::fs;
-use std::io::{Read, Write, ErrorKind};
+use std::io::{Read, Write, Error, ErrorKind};
 use std::path::Path;
-//use zip::{ZipWriter, CompressionMethod};
+use zip::{ZipWriter, CompressionMethod};
 
+/// Print all files in resources directory. Currently only being used for debugging
 fn list_files() {
     let paths = fs::read_dir("resources").unwrap();
 
@@ -20,59 +21,79 @@ fn list_files() {
 const DEPLOY_DIR: &'static str = "deployed";
 
 /// Create a deployment directory
-// TODO Add in result return type so that function/command can fail
-fn setup_deploy_dir() {
+fn setup_deploy_dir() -> Result<(), Error> {
     fs::create_dir(DEPLOY_DIR).or_else(|e| match e.kind() {
         ErrorKind::AlreadyExists => Ok(()),
         _ => Err(e),
     });
 
-    let deploy_dir = Path::new(DEPLOY_DIR);
     // Clean out any existing files that have been deployed.
-    for path in fs::read_dir(deploy_dir).unwrap() {
-        // TODO wrap the remove file in a try! macro
-        fs::remove_file(path.unwrap().path().as_path());
+    for path in fs::read_dir(Path::new(DEPLOY_DIR)).unwrap() {
+        try!(fs::remove_file(path.unwrap().path().as_path()));
     }
+    
+    Ok(())
 }
 
 /// Compress a directory and all of it's files
-// TODO Add in result return type so that function/command can fail
-// FIXME put try! macro around io
-fn zip_dir<P: AsRef<Path>>(dir: P, target_file: P) {
-    // TODO Implement compression/fix errors
-    /*let zip_file = fs::File::create(&target_file).unwrap();
+fn zip_dir<P: AsRef<Path>>(dir: P, target_file: P) -> Result<(), Error> {
+    let zip_file = fs::File::create(&target_file).unwrap();
     let mut zip = ZipWriter::new(zip_file);
-    zip.start_file(dir, CompressionMethod::Deflated);
+    //try!(zip.start_file(dir, CompressionMethod::Deflated));
+    // FIXME Make this use dir parameter
+    try!(zip.start_file("resources", CompressionMethod::Deflated));
 
     for path in fs::read_dir(dir).unwrap() {
         let file_path = path.unwrap();
         let mut file = fs::File::open(&file_path.path().as_path()).unwrap();
-        zip.start_file(file_path.path().file_name().unwrap().to_str().unwrap(), CompressionMethod::Deflated);
+        try!(zip.start_file(file_path.path().file_name().unwrap().to_str().unwrap(), CompressionMethod::Deflated));
 
         let mut file_body = String::new();
-        file.read_to_string(&mut file_body);
-        zip.write_all(file_body.as_bytes());
+        try!(file.read_to_string(&mut file_body));
+        try!(zip.write_all(file_body.as_bytes()));
     } 
 
-    zip.finish();*/
+    try!(zip.finish());
+    
+    Ok(())
 }
 
 /// Compresses and deploys the project as a distributable program.
 pub fn execute(_matches: &ArgMatches) -> cargo::CmdResult {
-    // TODO use new ? syntax or some other method of chaining these commands.
     try!(::subcmds::clean::execute(_matches));
     try!(::subcmds::test::execute(_matches));
     match ::subcmds::build::execute(_matches) {
         Ok(a) => {
             list_files();
-            setup_deploy_dir();
-            // FIXME wrap function call in try!
+            // FIXME Work out way to conver std::io::Error to &str
+            // TODO simplify this repeated code
+            match setup_deploy_dir() {
+                Ok(()) => (),
+                Err(e) => {
+                    println!("{}", e);
+                    return Err(&stringify!(e));
+                },
+            };
+            
             // FIXME Change format! macro to something better
-            zip_dir("resources", &format!("{}/{}", DEPLOY_DIR, "resources.zip"));
-            // FIXME wrap function call in try!
-            // TODO Implement way of copying correct binary
-            //fs::copy("target/release/filename", &format!("{}/{}", DEPLOY_DIR, "filename"));
-
+            match zip_dir("resources", &format!("{}/{}", DEPLOY_DIR, "resources.zip")) {
+                Ok(()) => (),
+                Err(e) => {
+                    println!("{}", e);
+                    return Err(&stringify!(e));
+                },
+            };
+            
+            // TODO Implement method of getting correct binary name
+            match fs::copy("target/release/filename", &format!("{}/{}", DEPLOY_DIR, "filename")) {
+                // function returns an unsigned int code. 
+                Ok(a) => (),
+                Err(e) => {
+                    println!("{}", e);
+                    return Err(&stringify!(e));
+                },
+            };
+            
             Ok(a)
         },
         Err(e) => Err(e),

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::io::{Read, Write, Error, ErrorKind};
 use std::path::Path;
 use zip::{ZipWriter, CompressionMethod};
+use walkdir::WalkDir;
 
 const DEPLOY_DIR: &'static str = "deploy";
 const RESOURCES_DIR: &'static str = "resources";
@@ -17,23 +18,43 @@ const RELEASE_BUILD_DIR: &'static str = "target/release";
 // FIXME Implement method of getting correct binary name - Find built binary and blind copy that?
 // FIXME cargo runtime arguments - build should include --release
 
-/// Print all files in resources directory. Currently only being used for debugging
-fn list_files(dir: &str) {
-    for path in fs::read_dir(dir).unwrap() {
-        println!("{}", path.unwrap().path().display())
+fn copy_binaries(origin: &str, dest: &str) -> Result<(), Error> {
+    // TODO Fail if no files were found?
+    // TODO better way of finding binaries
+    let binary_extensions = vec![".so", ".dylib", ".dll", ".exe"];
+
+    for path in fs::read_dir(origin).unwrap() {
+        // FIXME doesn't support unix binary extension yet
+        let file_path = path.unwrap().path();
+        if binary_extensions.contains(&file_path.extension().unwrap().to_str().unwrap()) {
+            try!(fs::copy(file_path.as_path(), &Path::new(dest).join(file_path.file_name().unwrap().to_str().unwrap())));
+        }
     }
+
+    Ok(())
+}
+
+fn create_dir(path: &str) -> Result<(), Error> {
+    println!("Creating directory at {}", path);
+    fs::create_dir(path).or_else(|e| match e.kind() {
+        ErrorKind::AlreadyExists => Ok(()),
+        _ => Err(e),
+    })
 }
 
 /// Create a deployment directory
 fn setup_deploy_dir() -> Result<(), Error> {
-    fs::create_dir(DEPLOY_DIR).or_else(|e| match e.kind() {
-        ErrorKind::AlreadyExists => Ok(()),
-        _ => return Err(e),
-    });
+    try!(create_dir(DEPLOY_DIR));
 
     // Clean out any existing files that have been deployed.
-    for path in fs::read_dir(Path::new(DEPLOY_DIR)).unwrap() {
-        try!(fs::remove_file(path.unwrap().path().as_path()));
+    // TODO change this to walk directories?
+    for entry in fs::read_dir(Path::new(DEPLOY_DIR)).unwrap() {
+        let entry = entry.unwrap().path();
+        if entry.is_dir() {
+            try!(fs::remove_dir_all(entry.as_path()));
+        } else {
+            try!(fs::remove_file(entry.as_path()));
+        }
     }
 
     Ok(())
@@ -41,21 +62,27 @@ fn setup_deploy_dir() -> Result<(), Error> {
 
 /// Compress a directory and all of it's files
 fn zip_dir(dir: &str, target_file: &str) -> Result<(), Error> {
-    println!("Compressing the following resources to: {}", target_file);
-    list_files(dir);
+    println!("Compressing the resources to: {}", target_file);
 
     let zip_file = fs::File::create(&Path::new(target_file)).unwrap();
     let mut zip = ZipWriter::new(zip_file);
-    try!(zip.start_file(dir, CompressionMethod::Deflated));
 
-    for path in fs::read_dir(dir).unwrap() {
-        let file_path = path.unwrap();
-        let mut file = fs::File::open(&file_path.path().as_path()).unwrap();
-        try!(zip.start_file(file_path.path().file_name().unwrap().to_str().unwrap(), CompressionMethod::Deflated));
+    for entry in WalkDir::new(dir) {
+        if let Ok(file_entry) = entry {
+            let path = file_entry.path();
 
-        let mut file_body = String::new();
-        try!(file.read_to_string(&mut file_body));
-        try!(zip.write_all(file_body.as_bytes()));
+            let file_os_string = path.to_path_buf().into_os_string();
+            let file_name = file_os_string.to_str().unwrap();
+            println!("Compressing file: {}", &file_name);
+            try!(zip.start_file(file_name, CompressionMethod::Deflated));
+
+            if !path.is_dir() {
+                let mut file = fs::File::open(&path).unwrap();
+                let mut file_body = String::new();
+                try!(file.read_to_string(&mut file_body));
+                try!(zip.write_all(file_body.as_bytes()));
+            }
+        }
     }
 
     try!(zip.finish());
@@ -64,15 +91,21 @@ fn zip_dir(dir: &str, target_file: &str) -> Result<(), Error> {
 }
 
 /// Compresses and deploys the project as a distributable program.
-pub fn execute(_matches: &ArgMatches) -> cargo::CmdResult {
-    println!("CLI args: {:?}", _matches);
+pub fn execute(matches: &ArgMatches) -> cargo::CmdResult {
+    println!("CLI args: {:?}", matches);
 
-    try!(::subcmds::test::execute(_matches));
-    match ::subcmds::build::execute(_matches) {
+    try!(::subcmds::test::execute(matches));
+    match ::subcmds::build::execute(matches) {
         Ok(a) => {
             tryio!(setup_deploy_dir());
+            tryio!(create_dir(&Path::new(DEPLOY_DIR).join("save").to_str().unwrap()));
+
+            // Compress Resources to zipfile in deploy directory
             tryio!(zip_dir(RESOURCES_DIR, &Path::new(DEPLOY_DIR).join(RESOURCES_ZIP_FILENAME).to_str().unwrap()));
-            tryio!(fs::copy(&Path::new(RELEASE_BUILD_DIR).join("filename").to_str().unwrap(), &Path::new(DEPLOY_DIR).join("filename").to_str().unwrap()));
+
+            // Copy compiled binaries - Amethyst system dynamic libraries and executable
+            // FIXME Currently does not work
+            //tryio!(copy_binaries(&Path::new(RELEASE_BUILD_DIR).to_str().unwrap(), &Path::new(DEPLOY_DIR).to_str().unwrap()));
 
             Ok(a)
         },

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -14,6 +14,11 @@ const DEPLOY_DIR: &'static str = "deploy";
 const RESOURCES_DIR: &'static str = "resources";
 const RESOURCES_ZIP_FILENAME: &'static str = "resources.zip";
 const BUILD_DIR: &'static str = "target/release";
+const MISSING_RESOURCES_DIR: &'static str = "Resources directory could not be found at ./resources.
+Amethyst projects require a Resources directory for storing config (input, graphics, etc) files and/or prefab/entity data.
+A Resources directory can be generated via the following options:
+1. Creating your own. See the documentation book here: http://www.amethyst.rs/book/getting_started/manual_cargo_setup.html#Resources%20Folder
+2. Generating a default directory. Simply use  amethyst new [project name]  and copy the generated resources directory into your own project.";
 
 fn get_executable_filename() -> Result<String, Error> {
     let mut file = try!(fs::File::open("Cargo.toml"));
@@ -128,17 +133,24 @@ pub struct Cmd;
 impl AmethystCmd for Cmd {
     /// Compresses and deploys the project as a distributable program.
     fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
-        try!(super::test::Cmd::execute(matches));
-        match super::build::Cmd::execute(matches) {
+        let cargo_args = vec!["release"];
+        println!("Running tests...");
+        try!(super::test::Cmd::execute(&cargo_args));
+        println!("Building project...");
+        match super::build::Cmd::execute(&cargo_args) {
             Ok(a) => {
                 try!(setup_deploy_dir());
 
-                // Compress Resources to zipfile in deploy directory
-                try!(zip_dir(RESOURCES_DIR,
-                             &Path::new(DEPLOY_DIR)
-                                  .join(RESOURCES_ZIP_FILENAME)
-                                  .to_str()
-                                  .unwrap()));
+                if Path::new(RESOURCES_DIR).exists() {
+                    // Compress Resources to zipfile in deploy directory
+                    try!(zip_dir(RESOURCES_DIR,
+                                 &Path::new(DEPLOY_DIR)
+                                      .join(RESOURCES_ZIP_FILENAME)
+                                      .to_str()
+                                      .unwrap()));
+                } else {
+                    return Err(MISSING_RESOURCES_DIR.into());
+                }
 
                 // Copy compiled binaries - Amethyst system dynamic libraries and executable
                 try!(copy_binaries(&Path::new(BUILD_DIR).to_str().unwrap(),

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -67,7 +67,6 @@ fn zip_dir(dir: &str, target_file: &str) -> Result<(), Error> {
 pub fn execute(_matches: &ArgMatches) -> cargo::CmdResult {
     println!("CLI args: {:?}", _matches);
 
-    try!(::subcmds::clean::execute(_matches));
     try!(::subcmds::test::execute(_matches));
     match ::subcmds::build::execute(_matches) {
         Ok(a) => {

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -4,7 +4,77 @@ use clap::ArgMatches;
 
 use cargo;
 
+use std::fs;
+use std::io::{Read, Write, ErrorKind};
+use std::path::Path;
+//use zip::{ZipWriter, CompressionMethod};
+
+fn list_files() {
+    let paths = fs::read_dir("resources").unwrap();
+
+    for path in paths {
+        println!("File: {}", path.unwrap().path().display())
+    }
+}
+
+const DEPLOY_DIR: &'static str = "deployed";
+
+/// Create a deployment directory
+// TODO Add in result return type so that function/command can fail
+fn setup_deploy_dir() {
+    fs::create_dir(DEPLOY_DIR).or_else(|e| match e.kind() {
+        ErrorKind::AlreadyExists => Ok(()),
+        _ => Err(e),
+    });
+
+    let deploy_dir = Path::new(DEPLOY_DIR);
+    // Clean out any existing files that have been deployed.
+    for path in fs::read_dir(deploy_dir).unwrap() {
+        // TODO wrap the remove file in a try! macro
+        fs::remove_file(path.unwrap().path().as_path());
+    }
+}
+
+/// Compress a directory and all of it's files
+// TODO Add in result return type so that function/command can fail
+// FIXME put try! macro around io
+fn zip_dir<P: AsRef<Path>>(dir: P, target_file: P) {
+    // TODO Implement compression/fix errors
+    /*let zip_file = fs::File::create(&target_file).unwrap();
+    let mut zip = ZipWriter::new(zip_file);
+    zip.start_file(dir, CompressionMethod::Deflated);
+
+    for path in fs::read_dir(dir).unwrap() {
+        let file_path = path.unwrap();
+        let mut file = fs::File::open(&file_path.path().as_path()).unwrap();
+        zip.start_file(file_path.path().file_name().unwrap().to_str().unwrap(), CompressionMethod::Deflated);
+
+        let mut file_body = String::new();
+        file.read_to_string(&mut file_body);
+        zip.write_all(file_body.as_bytes());
+    } 
+
+    zip.finish();*/
+}
+
 /// Compresses and deploys the project as a distributable program.
 pub fn execute(_matches: &ArgMatches) -> cargo::CmdResult {
-    unimplemented!();
+    // TODO use new ? syntax or some other method of chaining these commands.
+    try!(::subcmds::clean::execute(_matches));
+    try!(::subcmds::test::execute(_matches));
+    match ::subcmds::build::execute(_matches) {
+        Ok(a) => {
+            list_files();
+            setup_deploy_dir();
+            // FIXME wrap function call in try!
+            // FIXME Change format! macro to something better
+            zip_dir("resources", &format!("{}/{}", DEPLOY_DIR, "resources.zip"));
+            // FIXME wrap function call in try!
+            // TODO Implement way of copying correct binary
+            //fs::copy("target/release/filename", &format!("{}/{}", DEPLOY_DIR, "filename"));
+
+            Ok(a)
+        },
+        Err(e) => Err(e),
+    }
 }

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -98,7 +98,6 @@ pub fn execute(matches: &ArgMatches) -> cargo::CmdResult {
     match ::subcmds::build::execute(matches) {
         Ok(a) => {
             tryio!(setup_deploy_dir());
-            tryio!(create_dir(&Path::new(DEPLOY_DIR).join("save").to_str().unwrap()));
 
             // Compress Resources to zipfile in deploy directory
             tryio!(zip_dir(RESOURCES_DIR, &Path::new(DEPLOY_DIR).join(RESOURCES_ZIP_FILENAME).to_str().unwrap()));

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -17,7 +17,7 @@ const BUILD_DIR: &'static str = "target/debug";
 
 // FIXME cargo runtime arguments - build should include --release
 
-fn get_executable_filename() -> Result<&'static str, Error> {
+fn get_executable_filename() -> Result<String, Error> {
     let mut file = try!(fs::File::open("Cargo.toml"));
     let mut cargo_file_body = String::new();
     try!(file.read_to_string(&mut cargo_file_body));
@@ -25,9 +25,9 @@ fn get_executable_filename() -> Result<&'static str, Error> {
     let cargo_toml: ::toml::Value = cargo_file_body.parse().unwrap();
 
     match cargo_toml.lookup("bin.0.name") {
-        Some(name) => Ok(name.as_str().unwrap()),
+        Some(name) => Ok(name.as_str().unwrap().into()),
         // FIXME Unable to infer type information?????
-        None => Err(Error::new(ErrorKind::NotFound, "No executable name found in Cargo.toml".into())),
+        None => Err(Error::new::<String>(ErrorKind::NotFound, "No executable name found in Cargo.toml".into())),
     }
 }
 

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -126,7 +126,7 @@ impl AmethystCmd for Cmd {
         let cargo_args = vec!["release"];
         println!("Running tests...");
         try!(super::test::Cmd::execute(&cargo_args));
-        println!("Building project using {}", cargo_args);
+        println!("Building project...");
         match super::build::Cmd::execute(&cargo_args) {
             Ok(a) => {
                 tryio!(setup_deploy_dir());

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -14,11 +14,6 @@ const DEPLOY_DIR: &'static str = "deploy";
 const RESOURCES_DIR: &'static str = "resources";
 const RESOURCES_ZIP_FILENAME: &'static str = "resources.zip";
 const BUILD_DIR: &'static str = "target/release";
-const MISSING_RESOURCES_DIR: &'static str = "Resources directory could not be found at ./resources.
-Amethyst projects require a Resources directory for storing config (input, graphics, etc) files and/or prefab/entity data.
-A Resources directory can be generated via the following options:
-1. Creating your own. See the documentation book here: http://www.amethyst.rs/book/getting_started/manual_cargo_setup.html#Resources%20Folder
-2. Generating a default directory. Simply use  amethyst new [project name]  and copy the generated resources directory into your own project.";
 
 fn get_executable_filename() -> Result<String, Error> {
     let mut file = try!(fs::File::open("Cargo.toml"));
@@ -134,6 +129,10 @@ impl AmethystCmd for Cmd {
     /// Compresses and deploys the project as a distributable program.
     fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
         let cargo_args = vec!["release"];
+        if matches.is_present("clean") {
+            println!("Cleaning release build directory...");
+            try!(super::clean::Cmd::execute(&cargo_args));
+        }
         println!("Running tests...");
         try!(super::test::Cmd::execute(&cargo_args));
         println!("Building project...");
@@ -149,7 +148,11 @@ impl AmethystCmd for Cmd {
                                       .to_str()
                                       .unwrap()));
                 } else {
-                    return Err(MISSING_RESOURCES_DIR.into());
+                    return Err(cargo::CmdError::from("Resources directory could not be found at ./resources.
+Amethyst projects require a Resources directory for storing config (input, graphics, etc) files and/or prefab/entity data.
+A Resources directory can be generated via the following options:
+1. Creating your own. See the documentation book here: http://www.amethyst.rs/book/getting_started/manual_cargo_setup.html#Resources%20Folder
+2. Generating a default directory. Simply use  amethyst new [project name]  and copy the generated resources directory into your own project."));
                 }
 
                 // Copy compiled binaries - Amethyst system dynamic libraries and executable

--- a/src/cli/subcmds/mod.rs
+++ b/src/cli/subcmds/mod.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod clean;
+pub mod test;
 pub mod deploy;
 pub mod module;
 pub mod new;

--- a/src/cli/subcmds/new.rs
+++ b/src/cli/subcmds/new.rs
@@ -43,7 +43,7 @@ pub fn execute(matches: &ArgMatches) -> cargo::CmdResult {
         writeln!(file, "amethyst = \"*\"").unwrap();
         Ok(())
     } else {
-        Err("Failed to open Cargo.toml!")
+        Err(cargo::CmdError::from("Failed to open Cargo.toml!"))
     }
 }
 

--- a/src/cli/subcmds/test.rs
+++ b/src/cli/subcmds/test.rs
@@ -1,0 +1,10 @@
+//! The test command.
+
+use clap::ArgMatches;
+
+use cargo;
+
+/// Runs tests for the current Amethyst project.
+pub fn execute(_matches: &ArgMatches) -> cargo::CmdResult {
+    cargo::call(vec!["test", "--color=always"])
+}

--- a/tests.sh
+++ b/tests.sh
@@ -100,10 +100,31 @@ function check_clean() {
     exit 1
 }
 
+function check_deploy() {
+    echo "--- amethyst deploy"
+
+    ../amethyst deploy
+
+    #check that deploy dir, resources.zip, binary exists
+    if [ $? -eq 0 ] &&
+       [ -d deploy ] &&
+       [ -f deploy/mygame ] &&
+       [ -f deploy/resources.zip ]; then
+        echo "--- Passed!"
+        echo "--- Cleaning compiled and deployed files"
+        ../amethyst clean
+        rm -rf mygame/deployed
+  	    echo
+  	    return
+    fi
+
+    ls -l mygame/deployed
+    exit 1
+}
+
 function check_corrupt_build() {
     echo "--- amethyst build (corrupt)"
 
-    cd mygame
     rm -rf src
     ../amethyst build
 
@@ -125,6 +146,7 @@ check_new
 check_build
 check_run
 check_clean
+check_deploy
 check_corrupt_build
 
 echo

--- a/tests.sh
+++ b/tests.sh
@@ -103,7 +103,7 @@ function check_clean() {
 function check_deploy() {
     echo "--- amethyst deploy"
 
-    ../amethyst deploy
+    ../amethyst deploy --clean
 
     #check that deploy dir, resources.zip, binary exists
     if [ $? -eq 0 ] &&


### PR DESCRIPTION
Implements the `deploy` subcommand.

`deploy` cleans the relevant `target` directory, runs tests and builds the project. It then creates a `deploy` directory, zips all files (including the directory itself) in `resources`, and copies all dynamically linked libraries and binaries to `deploy`.
