### PR TITLE
New API for subcommands

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -10,6 +10,7 @@ extern crate zip;
 
 mod cargo;
 mod subcmds;
+use subcmds::amethyst_args::*;
 
 /// Ask clap if a given command-line argument was used, and if so, perform the
 /// corresponding action.
@@ -32,7 +33,7 @@ mod subcmds;
 macro_rules! execute_if {
     ($matches:expr, $term:ident) => (
         if let Some(matches) = $matches.subcommand_matches(stringify!($term)) {
-            match subcmds::$term::execute(matches) {
+            match subcmds::$term::Cmd::execute(matches) {
                 Ok(_) => std::process::exit(0),
                 Err(e) => {
                     println!("Error: {}", e);
@@ -68,7 +69,8 @@ fn main() {
         (@subcommand run =>
             (about: "Runs the main binary of the game")
             (@arg release: --release "Build artifacts in release mode, with optimizations"))
-        ).get_matches();
+        )
+                      .get_matches();
 
     execute_if!(matches, build);
     execute_if!(matches, clean);

--- a/src/cli/subcmds/amethyst_args.rs
+++ b/src/cli/subcmds/amethyst_args.rs
@@ -2,8 +2,15 @@ use clap::ArgMatches;
 
 use cargo;
 
+/// A common trait for Clap-like arguments used in Amethyst CLI.
+/// A need for this raised, when a need to call subcommands from runtime code appeared.
 pub trait AmethystArgs {
+    /// Returns if an argument was present.
     fn is_present(&self, name: &str) -> bool;
+
+    /// Gets the value of a specific option or positional argument (i.e. an argument that takes
+    /// an additional value at runtime). If the option wasn't present at runtime
+    /// it returns `None`.
     fn value_of(&self, name: &str) -> Option<&str>;
 }
 
@@ -41,6 +48,7 @@ impl<'a> AmethystArgs for Vec<&'a str> {
     }
 }
 
+/// A trait that should be implemented in order to be a subcommand for Amethyst CLI
 pub trait AmethystCmd {
     fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult;
 }

--- a/src/cli/subcmds/amethyst_args.rs
+++ b/src/cli/subcmds/amethyst_args.rs
@@ -1,0 +1,46 @@
+use clap::ArgMatches;
+
+use cargo;
+
+pub trait AmethystArgs {
+    fn is_present(&self, name: &str) -> bool;
+    fn value_of(&self, name: &str) -> Option<&str>;
+}
+
+impl<'a, 'b> AmethystArgs for ArgMatches<'a, 'b> {
+    fn is_present(&self, name: &str) -> bool {
+        self.is_present(name)
+    }
+
+    fn value_of(&self, name: &str) -> Option<&str> {
+        self.value_of(name)
+    }
+}
+
+impl<'a> AmethystArgs for Vec<&'a str> {
+    fn is_present(&self, name: &str) -> bool {
+        for &i in self {
+            if i == name {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn value_of(&self, name: &str) -> Option<&str> {
+        let idx_option = self.iter().position(|&item| item == name);
+        if let Some(idx) = idx_option {
+            if let Some(&res) = self.get(idx + 1) {
+                Some(res)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
+pub trait AmethystCmd {
+    fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult;
+}

--- a/src/cli/subcmds/build.rs
+++ b/src/cli/subcmds/build.rs
@@ -1,16 +1,19 @@
 //! The build command.
 
-use clap::ArgMatches;
-
 use cargo;
 
-/// Compiles the current Amethyst project.
-pub fn execute(matches: &ArgMatches) -> cargo::CmdResult {
-    let mut args = vec!["build", "--color=always"];
+use super::amethyst_args::{AmethystCmd, AmethystArgs};
+pub struct Cmd;
 
-    if matches.is_present("release") {
-        args.push("--release");
+impl AmethystCmd for Cmd {
+    /// Compiles the current Amethyst project.
+    fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
+        let mut args = vec!["build", "--color=always"];
+
+        if matches.is_present("release") {
+            args.push("--release");
+        }
+
+        cargo::call(args)
     }
-
-    cargo::call(args)
 }

--- a/src/cli/subcmds/clean.rs
+++ b/src/cli/subcmds/clean.rs
@@ -1,16 +1,19 @@
 //! The clean command.
 
-use clap::ArgMatches;
-
 use cargo;
 
-/// Removes the target directory.
-pub fn execute(matches: &ArgMatches) -> cargo::CmdResult {
-    let mut args = vec!["clean", "--color=always"];
+use super::amethyst_args::{AmethystCmd, AmethystArgs};
+pub struct Cmd;
 
-    if matches.is_present("release") {
-        args.push("--release");
+impl AmethystCmd for Cmd {
+    /// Removes the target directory.
+    fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
+        let mut args = vec!["clean", "--color=always"];
+
+        if matches.is_present("release") {
+            args.push("--release");
+        }
+
+        cargo::call(args)
     }
-
-    cargo::call(args)
 }

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -1,10 +1,13 @@
 //! The publish command.
 
-use clap::ArgMatches;
-
 use cargo;
 
-/// Compresses and deploys the project as a distributable program.
-pub fn execute(_matches: &ArgMatches) -> cargo::CmdResult {
-    unimplemented!();
+use super::amethyst_args::{AmethystCmd, AmethystArgs};
+pub struct Cmd;
+
+impl AmethystCmd for Cmd {
+    /// Compresses and deploys the project as a distributable program.
+    fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
+        unimplemented!();
+    }
 }

--- a/src/cli/subcmds/mod.rs
+++ b/src/cli/subcmds/mod.rs
@@ -1,6 +1,4 @@
 pub mod amethyst_args;
-
-pub use self::amethyst_args::*;
 pub mod build;
 pub mod clean;
 pub mod deploy;

--- a/src/cli/subcmds/mod.rs
+++ b/src/cli/subcmds/mod.rs
@@ -1,3 +1,6 @@
+pub mod amethyst_args;
+
+pub use self::amethyst_args::*;
 pub mod build;
 pub mod clean;
 pub mod deploy;

--- a/src/cli/subcmds/module.rs
+++ b/src/cli/subcmds/module.rs
@@ -1,9 +1,12 @@
 //! The module command.
 
-use clap::ArgMatches;
-
 use cargo;
 
-pub fn execute(_matches: &ArgMatches) -> cargo::CmdResult {
-    unimplemented!();
+use super::amethyst_args::{AmethystCmd, AmethystArgs};
+pub struct Cmd;
+
+impl AmethystCmd for Cmd {
+    fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
+        unimplemented!();
+    }
 }

--- a/src/cli/subcmds/run.rs
+++ b/src/cli/subcmds/run.rs
@@ -1,16 +1,19 @@
 //! The run command.
 
-use clap::ArgMatches;
-
 use cargo;
 
-/// Builds and executes the application.
-pub fn execute(matches: &ArgMatches) -> cargo::CmdResult {
-    let mut args = vec!["run", "--color=always"];
+use super::amethyst_args::{AmethystCmd, AmethystArgs};
+pub struct Cmd;
 
-    if matches.is_present("release") {
-        args.push("--release");
+impl AmethystCmd for Cmd {
+    /// Builds and executes the application.
+    fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
+        let mut args = vec!["run", "--color=always"];
+
+        if matches.is_present("release") {
+            args.push("--release");
+        }
+
+        cargo::call(args)
     }
-
-    cargo::call(args)
 }


### PR DESCRIPTION
As a need for subcommands to be run with vecs appeared(#23), I designed a pair of new traits:
- `AmethystArgs` is a common trait for Clap-like arguments. 
  It has two methods (`value_of`, `is_present`) and two implementations (for `clap::ArgMatches` and `Vec<&str>`). It is a common denominator to be used in Amethyst CLI and allows to abstractize from the details of implementation.
- `AmethystCmd` is a trait that should be implemented in order to call something a subcommand.
  It has one method (`fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult`) which is an entry point to every subcommand. Thus, all subcommands are called via `subcmnd_name::Cmd::execute(args)`.

This design, with little changes to existing code, allows to call `execute`s both with vecs and clap-args.

PS: All subcommands are update to be used with `AmethystCmd`
