### PR TITLE
Check for most commands if the project is an amethyst project

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ path = "src/cli/main.rs"
 [dependencies]
 clap = "1.5.5"
 zip = { version = "0.1.16", default-features = false }
+yaml-rust = "0.3.2"

--- a/src/cli/subcmds/build.rs
+++ b/src/cli/subcmds/build.rs
@@ -3,11 +3,13 @@
 use cargo;
 
 use super::amethyst_args::{AmethystCmd, AmethystArgs};
+use super::is_amethyst_project;
 pub struct Cmd;
 
 impl AmethystCmd for Cmd {
     /// Compiles the current Amethyst project.
     fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
+        try!(is_amethyst_project());
         let mut args = vec!["build", "--color=always"];
 
         if matches.is_present("release") {

--- a/src/cli/subcmds/clean.rs
+++ b/src/cli/subcmds/clean.rs
@@ -3,11 +3,13 @@
 use cargo;
 
 use super::amethyst_args::{AmethystCmd, AmethystArgs};
+use super::is_amethyst_project;
 pub struct Cmd;
 
 impl AmethystCmd for Cmd {
     /// Removes the target directory.
     fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
+        try!(is_amethyst_project());
         let mut args = vec!["clean", "--color=always"];
 
         if matches.is_present("release") {

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -156,6 +156,7 @@ pub struct Cmd;
 impl AmethystCmd for Cmd {
     /// Compresses and deploys the project as a distributable program.
     fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
+        try!(is_amethyst_project());
         let cargo_args = vec!["release"];
         if matches.is_present("clean") {
             println!("Cleaning release build directory...");

--- a/src/cli/subcmds/deploy.rs
+++ b/src/cli/subcmds/deploy.rs
@@ -9,6 +9,7 @@ use zip::{ZipWriter, CompressionMethod};
 use walkdir::WalkDir;
 
 use super::amethyst_args::{AmethystCmd, AmethystArgs};
+use super::is_amethyst_project;
 
 const DEPLOY_DIR: &'static str = "deploy";
 const RESOURCES_DIR: &'static str = "resources";

--- a/src/cli/subcmds/mod.rs
+++ b/src/cli/subcmds/mod.rs
@@ -5,3 +5,14 @@ pub mod deploy;
 pub mod module;
 pub mod new;
 pub mod run;
+
+use cargo;
+use std::path::Path;
+pub fn is_amethyst_project() -> cargo::CmdResult {
+    let config_path = Path::new(&".").join("resources").join("config.yml");
+    if config_path.exists() {
+        Ok(())
+    } else {
+        Err("The specified project is not an amethyst project.")
+    }
+}

--- a/src/cli/subcmds/mod.rs
+++ b/src/cli/subcmds/mod.rs
@@ -6,11 +6,23 @@ pub mod module;
 pub mod new;
 pub mod run;
 
+extern crate yaml_rust;
+
 use cargo;
 use std::path::Path;
+use self::yaml_rust::YamlLoader;
+use std::io::prelude::*;
+use std::fs::File;
+
 pub fn is_amethyst_project() -> cargo::CmdResult {
     let config_path = Path::new(&".").join("resources").join("config.yml");
     if config_path.exists() {
+        let mut f = try!(File::open(config_path).map_err(|_| "Couldn't open config.yml"));
+        let mut s = String::new();
+        try!(f.read_to_string(&mut s).map_err(|_| "config.yml is not a YAML file."));
+        let _ = try!(YamlLoader::load_from_str(&s).map_err(|_| "config.yml is not a valid YAML file."));
+
+        // No docs for what should be inside config.yml yet
         Ok(())
     } else {
         Err("The specified project is not an amethyst project.")

--- a/src/cli/subcmds/mod.rs
+++ b/src/cli/subcmds/mod.rs
@@ -20,7 +20,8 @@ pub fn is_amethyst_project() -> cargo::CmdResult {
         let mut f = try!(File::open(config_path).map_err(|_| "Couldn't open config.yml"));
         let mut s = String::new();
         try!(f.read_to_string(&mut s).map_err(|_| "config.yml is not a YAML file."));
-        let _ = try!(YamlLoader::load_from_str(&s).map_err(|_| "config.yml is not a valid YAML file."));
+        let _ = try!(YamlLoader::load_from_str(&s)
+                         .map_err(|_| "config.yml is not a valid YAML file."));
 
         // No docs for what should be inside config.yml yet
         Ok(())

--- a/src/cli/subcmds/mod.rs
+++ b/src/cli/subcmds/mod.rs
@@ -9,13 +9,13 @@ pub mod run;
 
 extern crate yaml_rust;
 
-use cargo;
 use std::path::Path;
 use self::yaml_rust::YamlLoader;
 use std::io::prelude::*;
 use std::fs::File;
+use cargo::*;
 
-pub fn is_amethyst_project() -> cargo::CmdResult {
+pub fn is_amethyst_project() -> CmdResult {
     let config_path = Path::new(&".").join("resources").join("config.yml");
     if config_path.exists() {
         let mut f = try!(File::open(config_path).map_err(|_| "Couldn't open config.yml"));
@@ -27,6 +27,6 @@ pub fn is_amethyst_project() -> cargo::CmdResult {
         // No docs for what should be inside config.yml yet
         Ok(())
     } else {
-        Err("The specified project is not an amethyst project.")
+        Err(CmdError::Err("The specified project is not an amethyst project.".into()))
     }
 }

--- a/src/cli/subcmds/module.rs
+++ b/src/cli/subcmds/module.rs
@@ -3,10 +3,12 @@
 use cargo;
 
 use super::amethyst_args::{AmethystCmd, AmethystArgs};
+use super::is_amethyst_project;
 pub struct Cmd;
 
 impl AmethystCmd for Cmd {
     fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
+        try!(is_amethyst_project());
         unimplemented!();
     }
 }

--- a/src/cli/subcmds/run.rs
+++ b/src/cli/subcmds/run.rs
@@ -3,11 +3,13 @@
 use cargo;
 
 use super::amethyst_args::{AmethystCmd, AmethystArgs};
+use super::is_amethyst_project;
 pub struct Cmd;
 
 impl AmethystCmd for Cmd {
     /// Builds and executes the application.
     fn execute<I: AmethystArgs>(matches: &I) -> cargo::CmdResult {
+        try!(is_amethyst_project());
         let mut args = vec!["run", "--color=always"];
 
         if matches.is_present("release") {

--- a/tests.sh
+++ b/tests.sh
@@ -2,10 +2,13 @@
 
 # Perform basic integration testing on amethyst_cli.
 
+function prepare() {
+    ln -s ./target/debug/amethyst .
+}
+
 function check_new() {
     echo "--- amethyst new"
 
-    ln -s ./target/debug/amethyst .
     ./amethyst new mygame
 
     if [ $? -eq 0 ] &&
@@ -29,7 +32,6 @@ function check_new() {
 function check_build() {
     echo "--- amethyst build"
 
-    cd mygame
     ../amethyst build
 
     if [ $? -eq 0 ]; then
@@ -103,8 +105,23 @@ function check_clean() {
 function check_corrupt_build() {
     echo "--- amethyst build (corrupt)"
 
-    cd mygame
     rm -rf src
+    ../amethyst build
+
+    if [ $? -ne 0 ]; then
+        echo "--- Passed!"
+        echo
+        return
+    fi
+
+    ls -l
+    exit 1
+}
+
+function check_noconfig_build() {
+    echo "--- amethyst build (no config)"
+
+    rm resources/config.yml
     ../amethyst build
 
     if [ $? -ne 0 ]; then
@@ -123,12 +140,25 @@ function clean_up() {
 
 clean_up
 cargo build
+prepare
 
 check_new
+cd mygame
 check_build
 check_run
 check_clean
+
+check_noconfig_build
+cd ..
+
+clean_up
+cargo build
+prepare
+
+./amethyst new mygame
+cd mygame
 check_corrupt_build
+
 
 echo
 echo "All tests pass!"


### PR DESCRIPTION
A function to check if a specified project appears to be a valid amethyst project.
- [x] Decide if `is_amethyst_project` should return bool or `CmdResult`. The latter is more convinient.
- [x] Current implementation checks only existence of config.yml and yml parsability. Probably it should also check contents, but they are not specified by the current documentation.
- [x] Tests
  - [x] Fail for build command if not an amethyst project
