### PR TITLE
add requirements section in readme for installing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ suggest ideas for more tools on [our issue tracker][it].
 
 ## Installing
 
+### Requirements
+* Ensure that you have the OpenSSL development headers installed (check for openssl-devel or something similar)
+
 By executing
 
 ```sh


### PR DESCRIPTION
When installing tools I noticed that https://github.com/sfackler/rust-openssl required the openssl headers via a slightly cryptic message. This makes new adopters aware of this requirement.