### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,22 +21,22 @@ name = "amethyst"
 path = "src/main.rs"
 
 [dependencies]
-ansi_term = "0.9"
-clap = "2"
-env_proxy = "0.2"
-error-chain = "0.11"
-lazy_static = "1.0.0"
-liquid = "0.14.3"
-regex = "0.2.10"
-reqwest = "0.7.1"
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
-walkdir = "2.1.4"
+ansi_term = "0.11.0"
+clap = "2.32.0"
+env_proxy = "0.2.0"
+error-chain = "0.12.0"
+lazy_static = "1.1.0"
+liquid = "0.15.0"
+regex = "1.0.5"
+reqwest = "0.9.2"
+serde = "1.0.79"
+serde_derive = "1.0.79"
+serde_json = "1.0.31"
+walkdir = "2.2.5"
 
 [dependencies.semver]
 features = ["serde"]
-version = "0.7"
+version = "0.9.0"
 
 [build-dependencies]
-ron = "0.1.3"
+ron = "0.4.0"

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -48,11 +48,11 @@ fn get_default_timeout() -> Duration {
 }
 
 fn get_with_timeout(url: &str, timeout: Duration) -> reqwest::Result<reqwest::Response> {
-    let client = reqwest::ClientBuilder::new()?
+    let client = reqwest::ClientBuilder::new()
         .timeout(timeout)
         .proxy(reqwest::Proxy::custom(|url| {
             env_proxy::for_url(url).to_url()
         }))
         .build()?;
-    client.get(url)?.send()
+    client.get(url).send()
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -17,8 +17,10 @@ struct Versions {
 
 #[derive(Deserialize)]
 struct CrateVersion {
-    #[serde(rename = "crate")] _name: String,
-    #[serde(rename = "num")] version: semver::Version,
+    #[serde(rename = "crate")]
+    _name: String,
+    #[serde(rename = "num")]
+    version: semver::Version,
     yanked: bool,
 }
 
@@ -36,8 +38,8 @@ pub fn get_latest_version() -> Result<String> {
 
 fn fetch_cratesio(path: &str) -> Result<Versions> {
     let url = format!("{host}/api/v1{path}", host = REGISTRY_HOST, path = path);
-    let response =
-        get_with_timeout(&url, get_default_timeout()).chain_err(|| ErrorKind::FetchVersionFailure)?;
+    let response = get_with_timeout(&url, get_default_timeout())
+        .chain_err(|| ErrorKind::FetchVersionFailure)?;
     let version: Versions =
         json::from_reader(response).chain_err(|| ErrorKind::InvalidCratesIoJson)?;
     Ok(version)
@@ -52,7 +54,6 @@ fn get_with_timeout(url: &str, timeout: Duration) -> reqwest::Result<reqwest::Re
         .timeout(timeout)
         .proxy(reqwest::Proxy::custom(|url| {
             env_proxy::for_url(url).to_url()
-        }))
-        .build()?;
+        })).build()?;
     client.get(url).send()
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -23,7 +23,7 @@ struct CrateVersion {
 }
 
 pub fn get_latest_version() -> Result<String> {
-    let crate_versions = fetch_cratesio(&format!("/crates/amethyst_tools"))?;
+    let crate_versions = fetch_cratesio("/crates/amethyst_tools")?;
     let dep = crate_versions
         .versions
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,23 +11,24 @@ extern crate serde;
 // This gives a warning until we add some uses for the fetch.rs code
 #[macro_use]
 extern crate serde_derive;
+extern crate liquid;
 extern crate serde_json;
 extern crate walkdir;
-extern crate liquid;
 #[macro_use]
 extern crate lazy_static;
-        
+
 use semver::Version;
 lazy_static! {
     pub static ref TEMPLATED_VERSIONS: Vec<Version> = {
         use std::{fs, path::Path};
-        let mut vers: Vec<Version> = fs::read_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join("templates"))
-            .unwrap()
-            .map(|version| {
-                let version = version.unwrap();
-                let filename = version.file_name().into_string().unwrap();
-                semver::Version::parse(&filename).unwrap()
-            }).collect();
+        let mut vers: Vec<Version> =
+            fs::read_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join("templates"))
+                .unwrap()
+                .map(|version| {
+                    let version = version.unwrap();
+                    let filename = version.file_name().into_string().unwrap();
+                    semver::Version::parse(&filename).unwrap()
+                }).collect();
         vers.sort_unstable();
         vers
     };
@@ -39,5 +40,5 @@ pub mod error;
 pub use fetch::get_latest_version;
 mod templates;
 
-mod new;
 mod fetch;
+mod new;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,7 @@ fn main() {
                     Arg::with_name("project_name")
                         .help("The directory name for the new project")
                         .required(true),
-                )
-                .arg(
+                ).arg(
                     Arg::with_name("amethyst_version")
                         .short("a")
                         .long("amethyst")
@@ -32,8 +31,7 @@ fn main() {
                         .takes_value(true)
                         .help("The requested version of Amethyst"),
                 ),
-        )
-        .subcommand(
+        ).subcommand(
             SubCommand::with_name("update")
                 .about("Checks if you can update Amethyst component")
                 .arg(
@@ -42,8 +40,7 @@ fn main() {
                         .value_name("COMPONENT_NAME")
                         .takes_value(true),
                 ),
-        )
-        .setting(AppSettings::SubcommandRequiredElseHelp)
+        ).setting(AppSettings::SubcommandRequiredElseHelp)
         .get_matches();
 
     match matches.subcommand() {
@@ -54,7 +51,8 @@ fn main() {
 }
 
 fn exec_new(args: &ArgMatches) {
-    let project_name = args.value_of("project_name")
+    let project_name = args
+        .value_of("project_name")
         .expect("Bug: project_name is required");
     let project_name = project_name.to_owned();
     let version = args.value_of("amethyst_version").map(|v| v.to_owned());

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,16 +62,15 @@ fn exec_new(args: &ArgMatches) {
     let n = cli::New {
         project_name,
         version,
-        ..Default::default()
     };
 
     if let Err(e) = n.execute() {
-        handle_error(e);
+        handle_error(&e);
     } else {
         println!("Project ready!");
         println!("Checking for updates...");
         if let Err(e) = check_version() {
-            handle_error(e);
+            handle_error(&e);
         }
     }
 }
@@ -80,7 +79,7 @@ fn exec_update(args: &ArgMatches) {
     // We don't currently support checking anything other than the version of amethyst tools
     let _component_name = args.value_of("component_name").map(|c| c.to_owned());
     if let Err(e) = check_version() {
-        handle_error(e);
+        handle_error(&e);
     }
     exit(0);
 }
@@ -106,7 +105,7 @@ fn check_version() -> cli::error::Result<()> {
     }
     Ok(())
 }
-fn handle_error(e: cli::error::Error) {
+fn handle_error(e: &cli::error::Error) {
     use ansi_term::Color;
 
     eprintln!("{}: {}", Color::Red.paint("error"), e);

--- a/src/new.rs
+++ b/src/new.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
 use std::collections::HashMap;
 use std::fs::{create_dir, remove_dir_all};
+use std::path::Path;
 
 use error::{ErrorKind, Result, ResultExt};
 use templates;
@@ -27,9 +27,13 @@ impl New {
         create_dir(path).chain_err(|| "could not create project folder")?;
 
         let mut params = templates::Parameters::new();
-        params.insert("project_name".to_owned(), templates::Value::scalar(&self.project_name));
+        params.insert(
+            "project_name".to_owned(),
+            templates::Value::scalar(&self.project_name),
+        );
 
-        if let Err(err) = templates::deploy("main", &self.version, &path, &params, &HashMap::new()) {
+        if let Err(err) = templates::deploy("main", &self.version, &path, &params, &HashMap::new())
+        {
             remove_dir_all(path).chain_err(|| "could not clean up project folder")?;
             Err(err)
         } else {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -15,7 +15,7 @@ pub use liquid::{Object as Parameters, Value};
 
 use TEMPLATED_VERSIONS;
 
-const LIQUID_TEMPLATE_EXTENSION: &'static str = ".gdpu";
+const LIQUID_TEMPLATE_EXTENSION: &str = ".gdpu";
 
 pub fn deploy(
     template: &str,
@@ -26,10 +26,10 @@ pub fn deploy(
 ) -> Result<()> {
     let parser = ParserBuilder::with_liquid().build();
     let version = match version {
-        &Some(ref ver) => {
+        Some(ref ver) => {
             semver::Version::parse(ver).chain_err(|| format!("Could not parse version {}", ver))?
         }
-        &None => TEMPLATED_VERSIONS
+        None => TEMPLATED_VERSIONS
             .iter()
             .max()
             .ok_or("No template available")?
@@ -72,7 +72,7 @@ pub fn deploy(
 
         let mut output_name = renaming_rules
             .get(&file_name)
-            .map(|x| x.clone())
+            .cloned()
             .unwrap_or(file_name);
         let is_parsed = output_name.ends_with(LIQUID_TEMPLATE_EXTENSION);
         if is_parsed {
@@ -83,7 +83,7 @@ pub fn deploy(
         let parent_path = entry
             .path()
             .parent()
-            .ok_or(format!("Could not get the parent of {:?}", entry.path()))?
+            .ok_or_else(|| format!("Could not get the parent of {:?}", entry.path()))?
             .strip_prefix(&template_path)
             .chain_err(|| format!("Could not remove root of path {:?}", entry.path()))?;
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -70,10 +70,7 @@ pub fn deploy(
             .into_string()
             .map_err(|_| format!("Failed to get the file name from {:?}", entry.path()))?;
 
-        let mut output_name = renaming_rules
-            .get(&file_name)
-            .cloned()
-            .unwrap_or(file_name);
+        let mut output_name = renaming_rules.get(&file_name).cloned().unwrap_or(file_name);
         let is_parsed = output_name.ends_with(LIQUID_TEMPLATE_EXTENSION);
         if is_parsed {
             let len = output_name.len();


### PR DESCRIPTION
There's a new version of `openssl` arriving at some linux distributions' repositories, so there's a need to update dependencies that rely on it so as to use the newer version of the bindings.

Let me know if you prefer that I don't apply `rustfmt` and I'll remove that commit.

Fixes #61