### PR TITLE
Generate 0.10.0 projects with 2018 edition

### DIFF
--- a/templates/0.10.0/main/Cargo.toml.gdpu
+++ b/templates/0.10.0/main/Cargo.toml.gdpu
@@ -2,6 +2,7 @@
 name = "{{ project_name }}"
 version = "0.1.0"
 authors = []
+edition = "2018"
 
 [dependencies]
 amethyst = "{{ amethyst_version }}"


### PR DESCRIPTION
2018 edition is now the default with `cargo new`, so I think this makes sense.