### PR TITLE
Added template for 0.11.0 with `application_root_dir` changes.

### DIFF
--- a/templates/0.11.0/main/Cargo.toml.gdpu
+++ b/templates/0.11.0/main/Cargo.toml.gdpu
@@ -1,0 +1,8 @@
+[package]
+name = "{{ project_name }}"
+version = "0.1.0"
+authors = []
+edition = "2018"
+
+[dependencies]
+amethyst = "{{ amethyst_version }}"

--- a/templates/0.11.0/main/resources/display_config.ron.gdpu
+++ b/templates/0.11.0/main/resources/display_config.ron.gdpu
@@ -1,0 +1,10 @@
+(
+  title: "{{ project_name }}",
+  dimensions: None,
+  max_dimensions: None,
+  min_dimensions: None,
+  fullscreen: false,
+  multisampling: 1,
+  visibility: true,
+  vsync: true,
+)

--- a/templates/0.11.0/main/src/main.rs.gdpu
+++ b/templates/0.11.0/main/src/main.rs.gdpu
@@ -1,0 +1,35 @@
+extern crate amethyst;
+
+use amethyst::{
+    prelude::*,
+    renderer::{DisplayConfig, DrawFlat, Pipeline, PosNormTex, RenderBundle, Stage},
+    utils::application_root_dir,
+};
+
+struct Example;
+
+impl SimpleState for Example {}
+
+fn main() -> amethyst::Result<()> {
+    amethyst::start_logger(Default::default());
+
+    let mut path = application_root_dir()?;
+    path.push("resources");
+    path.push("display_config.ron");
+
+    let config = DisplayConfig::load(&path);
+
+    let pipe = Pipeline::build().with_stage(
+        Stage::with_backbuffer()
+            .clear_target([0.00196, 0.23726, 0.21765, 1.0], 1.0)
+            .with_pass(DrawFlat::<PosNormTex>::new()),
+    );
+
+    let game_data =
+        GameDataBuilder::default().with_bundle(RenderBundle::new(pipe, Some(config)))?;
+    let mut game = Application::new("./", Example, game_data)?;
+
+    game.run();
+
+    Ok(())
+}


### PR DESCRIPTION
Related: https://github.com/amethyst/amethyst/issues/1325

Main change is:

```patch
-let path = format!(
-    "{}/resources/display_config.ron",
-    application_root_dir()
-);
+let mut path = application_root_dir()?;
+path.push("resources");
+path.push("display_config.ron");
```