### PR TITLE
Remove useless extern crate from templates

### DIFF
--- a/templates/0.10.0/main/src/main.rs.gdpu
+++ b/templates/0.10.0/main/src/main.rs.gdpu
@@ -1,5 +1,3 @@
-extern crate amethyst;
-
 use amethyst::{
     prelude::*,
     renderer::{DisplayConfig, DrawFlat, Pipeline, PosNormTex, RenderBundle, Stage},

--- a/templates/0.11.0/main/src/main.rs.gdpu
+++ b/templates/0.11.0/main/src/main.rs.gdpu
@@ -1,5 +1,3 @@
-extern crate amethyst;
-
 use amethyst::{
     prelude::*,
     renderer::{DisplayConfig, DrawFlat, Pipeline, PosNormTex, RenderBundle, Stage},


### PR DESCRIPTION
Hi,

I noticed that `amethyst new project` create a Cargo.toml file with `edition = "2018"` but in main.rs it still includes `extern crate amethyst;` which is not needed anymore with this new rust edition.

Someone on the discord server suggested me to make a PR for this, so here it is. It is my all-time first PR though, so I hope I didn't do anything wrong.