### PR TITLE
Include template files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,12 @@ ansi_term = "0.11.0"
 clap = "2.32.0"
 env_proxy = "0.2.0"
 error-chain = "0.12.0"
-lazy_static = "1.1.0"
 liquid = "0.15.0"
 regex = "1.0.5"
 reqwest = "0.9.2"
 serde = "1.0.79"
 serde_derive = "1.0.79"
 serde_json = "1.0.31"
-walkdir = "2.2.5"
 
 [dependencies.semver]
 features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.7.6"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Game development tools for the Amethyst engine"
 keywords = ["game", "engine", "tool", "editor", "amethyst"]
+build = "build.rs"
 
 repository = "https://github.com/ebkalderon/amethyst_tools"
 
@@ -40,3 +41,4 @@ version = "0.9.0"
 
 [build-dependencies]
 ron = "0.4.0"
+walkdir = "2.2.5"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,56 @@
+//! Reads the `templates/` directory and includes all versions' templates as
+//! part of the binary to reduce installation footprint
+extern crate ron;
+
+use std::env;
+use std::fs::{read_dir, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use ron::de::from_reader;
+
+fn path(env: &str, s: &str) -> PathBuf {
+    PathBuf::from(env::var(env).unwrap()).join(s)
+}
+
+fn read_template_index<P: AsRef<Path>>(p: P) -> Vec<String> {
+    let mut path = PathBuf::new();
+    path.push(p);
+    path.push("index.ron");
+    from_reader(File::open(&path).expect("Failed to open index.ron"))
+        .expect("Failed to parse template index")
+}
+
+fn main() {
+    let f = PathBuf::from(path("CARGO_MANIFEST_DIR", "templates"));
+    let indices = read_dir(&f).unwrap().map(Result::unwrap).map(|v| {
+        (
+            v.file_name().into_string().unwrap(),
+            read_template_index(v.path()),
+        )
+    });
+
+    let mut source_code = String::from(
+        "use std::collections::HashMap;
+    
+pub fn template_files() -> HashMap<&'static str, Vec<(&'static str, &'static str)>> {
+    let mut map = HashMap::new();
+",
+    );
+    for (version, index) in indices {
+        source_code.push_str(&format!("    map.insert({:?}, ", version));
+        source_code.push_str(&index.iter().fold("vec![".to_owned(), |s, file| {
+            format!(
+                "{}({:?}, include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"),\
+                 concat!(\"/templates/\", concat!(concat!({:?}, \"/\"), {:?}))))), ",
+                s, file, version, file,
+            )
+        }));
+        source_code.push_str("]);\n")
+    }
+    source_code += "    map\n}\n";
+    File::create(&path("OUT_DIR", "_template_files.rs"))
+        .expect("Failed to embed template files")
+        .write_all(source_code.as_bytes())
+        .expect("Failed to write to destination");
+}

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ extern crate ron;
 use std::env;
 use std::fs::{read_dir, File};
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use ron::de::from_reader;
 
@@ -13,9 +13,9 @@ fn path(env: &str, s: &str) -> PathBuf {
     PathBuf::from(env::var(env).unwrap()).join(s)
 }
 
-fn read_template_index<P: AsRef<Path>>(p: P) -> Vec<String> {
+fn read_template_index<P: Into<PathBuf>>(p: P) -> Vec<String> {
     let mut path = PathBuf::new();
-    path.push(p);
+    path.push(p.into());
     path.push("index.ron");
     from_reader(File::open(&path).expect("Failed to open index.ron"))
         .expect("Failed to parse template index")

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -54,6 +54,7 @@ fn get_with_timeout(url: &str, timeout: Duration) -> reqwest::Result<reqwest::Re
         .timeout(timeout)
         .proxy(reqwest::Proxy::custom(|url| {
             env_proxy::for_url(url).to_url()
-        })).build()?;
+        }))
+        .build()?;
     client.get(url).send()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,28 +11,9 @@ extern crate serde;
 // This gives a warning until we add some uses for the fetch.rs code
 #[macro_use]
 extern crate serde_derive;
+extern crate core;
 extern crate liquid;
 extern crate serde_json;
-extern crate walkdir;
-#[macro_use]
-extern crate lazy_static;
-
-use semver::Version;
-lazy_static! {
-    pub static ref TEMPLATED_VERSIONS: Vec<Version> = {
-        use std::{fs, path::Path};
-        let mut vers: Vec<Version> =
-            fs::read_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join("templates"))
-                .unwrap()
-                .map(|version| {
-                    let version = version.unwrap();
-                    let filename = version.file_name().into_string().unwrap();
-                    semver::Version::parse(&filename).unwrap()
-                }).collect();
-        vers.sort_unstable();
-        vers
-    };
-}
 
 pub use new::New;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,8 @@ fn main() {
                     Arg::with_name("project_name")
                         .help("The directory name for the new project")
                         .required(true),
-                ).arg(
+                )
+                .arg(
                     Arg::with_name("amethyst_version")
                         .short("a")
                         .long("amethyst")
@@ -31,7 +32,8 @@ fn main() {
                         .takes_value(true)
                         .help("The requested version of Amethyst"),
                 ),
-        ).subcommand(
+        )
+        .subcommand(
             SubCommand::with_name("update")
                 .about("Checks if you can update Amethyst component")
                 .arg(
@@ -40,7 +42,8 @@ fn main() {
                         .value_name("COMPONENT_NAME")
                         .takes_value(true),
                 ),
-        ).setting(AppSettings::SubcommandRequiredElseHelp)
+        )
+        .setting(AppSettings::SubcommandRequiredElseHelp)
         .get_matches();
 
     match matches.subcommand() {

--- a/src/new.rs
+++ b/src/new.rs
@@ -36,7 +36,11 @@ impl New {
             remove_dir_all(path).chain_err(|| "could not clean up project folder")?;
             Err(err)
         } else {
-            Command::new("git").arg("init").current_dir(path).spawn()?.try_wait()?;
+            Command::new("git")
+                .arg("init")
+                .current_dir(path)
+                .spawn()?
+                .try_wait()?;
             Ok(())
         }
     }

--- a/src/new.rs
+++ b/src/new.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fs::{create_dir, remove_dir_all};
 use std::path::Path;
 use std::process::Command;
@@ -33,8 +32,7 @@ impl New {
             templates::Value::scalar(&self.project_name),
         );
 
-        if let Err(err) = templates::deploy("main", &self.version, &path, &params, &HashMap::new())
-        {
+        if let Err(err) = templates::deploy("main", &self.version, &path, &params) {
             remove_dir_all(path).chain_err(|| "could not clean up project folder")?;
             Err(err)
         } else {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,19 +1,19 @@
 /// Wrapper around the ``liquid`` crate to handle templating.
 use liquid::ParserBuilder;
 
-use std::collections::HashMap;
-use std::fs;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::Path;
+use std::fs::{create_dir_all, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use error::{Result, ResultExt};
+
 use semver;
-use walkdir::WalkDir;
 
 pub use liquid::{Object as Parameters, Value};
 
-use TEMPLATED_VERSIONS;
+mod external {
+    include!(concat!(env!("OUT_DIR"), "/_template_files.rs"));
+}
 
 const LIQUID_TEMPLATE_EXTENSION: &str = ".gdpu";
 
@@ -22,121 +22,80 @@ pub fn deploy(
     version: &Option<String>,
     output: &Path,
     params: &Parameters,
-    renaming_rules: &HashMap<String, String>,
 ) -> Result<()> {
     let parser = ParserBuilder::with_liquid().build();
+    let template_map = external::template_files();
+    let template_versions = template_map
+        .keys()
+        .map(|v| semver::Version::parse(v).unwrap());
     let version = match version {
-        Some(ref ver) => {
-            semver::Version::parse(ver).chain_err(|| format!("Could not parse version {}", ver))?
-        }
-        None => TEMPLATED_VERSIONS
-            .iter()
+        Some(ref ver) => semver::Version::parse(ver)
+            .chain_err(|| format!("Could not parse version {}", ver))?
+            .to_string(),
+        None => template_versions
+            .into_iter()
             .max()
             .ok_or("No template available")?
-            .clone(),
+            .to_string(),
     };
 
     let mut par = params.clone();
     par.insert(
         "amethyst_version".to_owned(),
-        Value::scalar(format!("{}", version)),
+        Value::scalar(version.to_owned()),
     );
     let params = &par;
 
-    let template_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("templates");
+    for &(path, content) in template_map.get::<str>(&version.to_owned()).unwrap().iter() {
+        let mut path = path.to_owned();
 
-    // Find the highest templated version where the template is implemented, smaller than the requested version
-    let version = TEMPLATED_VERSIONS
-        .iter()
-        .rev()
-        .skip_while(|x| **x > version)
-        .find(|x| template_path.join(format!("{}", x)).join(template).exists())
-        .ok_or_else(|| {
-            format!(
-                "Version {} not supported (template \"{}\" not found)",
-                version, template
-            )
-        })?;
-    let version = format!("{}", version);
-
-    let template_path = template_path.join(version).join(template);
-
-    for entry in WalkDir::new(&template_path).min_depth(1) {
-        let entry =
-            entry.chain_err(|| "Could not walk over one of the template's directory entry")?;
-        let file_name = entry
-            .file_name()
-            .to_os_string()
-            .into_string()
-            .map_err(|_| format!("Failed to get the file name from {:?}", entry.path()))?;
-
-        let mut output_name = renaming_rules.get(&file_name).cloned().unwrap_or(file_name);
-        let is_parsed = output_name.ends_with(LIQUID_TEMPLATE_EXTENSION);
+        let is_parsed = path.ends_with(LIQUID_TEMPLATE_EXTENSION);
         if is_parsed {
-            let len = output_name.len();
-            output_name.truncate(len - LIQUID_TEMPLATE_EXTENSION.len());
+            let len = path.len();
+            path.truncate(len - LIQUID_TEMPLATE_EXTENSION.len());
         }
 
-        let parent_path = entry
-            .path()
-            .parent()
-            .ok_or_else(|| format!("Could not get the parent of {:?}", entry.path()))?
-            .strip_prefix(&template_path)
-            .chain_err(|| format!("Could not remove root of path {:?}", entry.path()))?;
-
-        let final_path = output.join(parent_path).join(output_name);
-
-        // WalkDir ensures directories are treated before their content
-        if entry.file_type().is_dir() {
-            fs::create_dir(&final_path)
-                .chain_err(|| format!("Could not create directory at {:?}", final_path))?;
-        } else if entry.file_type().is_file() {
-            if is_parsed {
-                let mut template_raw = String::new();
-                File::open(entry.path())
-                    .chain_err(|| format!("Could not open file at {:?}", final_path))?
-                    .read_to_string(&mut template_raw)
-                    .chain_err(|| format!("Could not read file at {:?}", final_path))?;
-                let mut out = parser
-                    .parse(&template_raw)
-                    .chain_err(|| format!("Could not parse liquid template at {:?}", entry.path()))?
-                    .render(params)
-                    .chain_err(|| {
-                        format!(
-                            "Could not render liquid template at {:?} with parameters {:?}",
-                            entry.path(),
-                            params
-                        )
-                    })?;
-
-                #[cfg(target_os = "windows")]
-                {
-                    use regex::Regex;
-
-                    out = Regex::new("(?P<last>[^\r])\n")
-                        .unwrap()
-                        .replace_all(&out, "$last\r\n")
-                        .to_string();
-                }
-                #[cfg(not(target_os = "windows"))]
-                {
-                    out = out.replace("\r\n", "\n");
-                }
-
-                File::create(&final_path)
-                    .chain_err(|| format!("Could not create file at {:?}", final_path))?
-                    .write_all(out.as_bytes())
-                    .chain_err(|| format!("Could not write file at {:?}", final_path))?;
-            } else {
-                fs::copy(entry.path(), &final_path).chain_err(|| {
+        let mut out = if is_parsed {
+            parser
+                .parse(content)
+                .chain_err(|| format!("Could not parse liquid template at {:?}", path))?
+                .render(params)
+                .chain_err(|| {
                     format!(
-                        "Could not copy file at {:?} to {:?}",
-                        entry.path(),
-                        final_path
+                        "Could not render liquid template at {:?} with parameters {:?}",
+                        path, params
                     )
-                })?;
-            }
+                })?
+        } else {
+            content.to_owned()
+        };
+
+        #[cfg(target_os = "windows")]
+        {
+            use regex::Regex;
+
+            out = Regex::new("(?P<last>[^\r])\n")
+                .unwrap()
+                .replace_all(&out, "$last\r\n")
+                .to_string();
         }
+        #[cfg(not(target_os = "windows"))]
+        {
+            out = out.replace("\r\n", "\n");
+        }
+
+        let path: PathBuf = output
+            .join(path)
+            .iter()
+            .enumerate()
+            .filter_map(|(_, e)| if e != template { Some(e) } else { None })
+            .collect();
+
+        create_dir_all(path.parent().expect("Path has no parent"))?;
+        File::create(&path)
+            .chain_err(|| format!("failed to create file {:?}", &path))?
+            .write_all(out.as_bytes())
+            .chain_err(|| format!("could not write contents to file {:?}", &path))?;
     }
 
     Ok(())

--- a/templates/0.10.0/index.ron
+++ b/templates/0.10.0/index.ron
@@ -1,0 +1,6 @@
+[
+    "main/.gitignore",
+    "main/Cargo.toml.gdpu",
+    "main/src/main.rs.gdpu",
+    "main/resources/display_config.ron.gdpu",
+]

--- a/templates/0.11.0/index.ron
+++ b/templates/0.11.0/index.ron
@@ -1,0 +1,6 @@
+[
+    "main/.gitignore",
+    "main/Cargo.toml.gdpu",
+    "main/src/main.rs.gdpu",
+    "main/resources/display_config.ron.gdpu",
+]

--- a/templates/0.6.0/index.ron
+++ b/templates/0.6.0/index.ron
@@ -1,0 +1,6 @@
+[
+    "main/.gitignore",
+    "main/Cargo.toml.gdpu",
+    "main/src/main.rs.gdpu",
+    "main/resources/display_config.ron.gdpu",
+]

--- a/templates/0.7.0/index.ron
+++ b/templates/0.7.0/index.ron
@@ -1,0 +1,6 @@
+[
+    "main/.gitignore",
+    "main/Cargo.toml.gdpu",
+    "main/src/main.rs.gdpu",
+    "main/resources/display_config.ron.gdpu",
+]

--- a/templates/0.8.0/index.ron
+++ b/templates/0.8.0/index.ron
@@ -1,0 +1,6 @@
+[
+    "main/.gitignore",
+    "main/Cargo.toml.gdpu",
+    "main/src/main.rs.gdpu",
+    "main/resources/display_config.ron.gdpu",
+]

--- a/templates/0.9.0/index.ron
+++ b/templates/0.9.0/index.ron
@@ -1,0 +1,6 @@
+[
+    "main/.gitignore",
+    "main/Cargo.toml.gdpu",
+    "main/src/main.rs.gdpu",
+    "main/resources/display_config.ron.gdpu",
+]


### PR DESCRIPTION
This PR adds the build script functionality back and changes `deploy` to use the included files.

Note that the build script doesn't account for different templates, only `main` templates.  Thus, `deploy` doesn't change its behavior based on the `template` parameter. I'll open an issue to add functionality to determine more templates if and when this PR is merged.

Closes #71