### PR TITLE
 Removed the dependency on the OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,14 @@ env_proxy = "0.3.1"
 error-chain = "0.12.1"
 liquid = "0.18.2"
 regex = "1.1.7"
-reqwest = "0.9.18"
 serde = "1.0.92"
 serde_derive = "1.0.92"
 serde_json = "1.0.39"
+
+[dependencies.reqwest]
+version = "0.9.18"
+default-features = false
+features = ["rustls-tls"]
 
 [dependencies.semver]
 features = ["serde"]

--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@ like:
 
 ## Installing
 
-### Requirements
-* Ensure that you have the OpenSSL development headers installed (check for
-openssl-devel or something similar)
-
 By executing
 
 ```sh


### PR DESCRIPTION
This PR is an attempt to make the amethyst cli more accessible by removing the dependency on `openssl`, so that the users would not have to spend time finding and installing necessary dependencies.

This is done by enabling the `rust-tls` feature of the reqwest crate.
Since the crate is currently used only once, perhaps the switch between the `openssl` and `rust-tls` is not that significant.