### PR TITLE
Add template for the 0.12 release

### DIFF
--- a/templates/0.12.0/index.ron
+++ b/templates/0.12.0/index.ron
@@ -1,0 +1,7 @@
+[
+    "main/.gitignore",
+    "main/README.md.gdpu",
+    "main/Cargo.toml.gdpu",
+    "main/src/main.rs.gdpu",
+    "main/config/display.ron.gdpu",
+]

--- a/templates/0.12.0/main/.gitignore
+++ b/templates/0.12.0/main/.gitignore
@@ -1,0 +1,9 @@
+# Unwanted files
+target
+
+# Backup files
+.DS_Store
+thumbs.db
+*~
+*.rs.bk
+*.swp

--- a/templates/0.12.0/main/Cargo.toml.gdpu
+++ b/templates/0.12.0/main/Cargo.toml.gdpu
@@ -1,0 +1,13 @@
+[package]
+name = "{{ project_name }}"
+version = "0.1.0"
+authors = []
+edition = "2018"
+
+[dependencies]
+amethyst = "{{ amethyst_version }}"
+
+[features]
+empty = ["amethyst/empty"]
+metal = ["amethyst/metal"]
+vulkan = ["amethyst/vulkan"]

--- a/templates/0.12.0/main/README.md.gdpu
+++ b/templates/0.12.0/main/README.md.gdpu
@@ -1,0 +1,26 @@
+# {{ project_name }}
+
+## How to run
+
+To run the game, use
+
+```
+cargo run --features "vulkan"
+```
+
+on Windows and Linux, and
+
+```
+cargo run --features "metal"
+```
+
+on macOS.
+
+For building without any graphics backend, you can use
+
+```
+cargo run --features "empty"
+```
+
+but be aware that as soon as you need any rendering you won't be able to run your game when using
+the `empty` feature.

--- a/templates/0.12.0/main/config/display.ron.gdpu
+++ b/templates/0.12.0/main/config/display.ron.gdpu
@@ -1,0 +1,4 @@
+(
+  title: "{{ project_name }}",
+  dimensions: Some((500, 500)),
+)

--- a/templates/0.12.0/main/src/main.rs.gdpu
+++ b/templates/0.12.0/main/src/main.rs.gdpu
@@ -1,0 +1,42 @@
+use amethyst::{
+    core::transform::TransformBundle,
+    ecs::prelude::{ReadExpect, Resources, SystemData},
+    prelude::*,
+    renderer::{
+        plugins::{RenderFlat2D, RenderToWindow},
+        types::DefaultBackend,
+        RenderingBundle,
+    },
+    utils::application_root_dir,
+};
+
+struct MyState;
+
+impl SimpleState for MyState {
+    fn on_start(&mut self, _data: StateData<'_, GameData<'_, '_>>) {}
+}
+
+fn main() -> amethyst::Result<()> {
+    amethyst::start_logger(Default::default());
+
+    let app_root = application_root_dir()?;
+
+    let config_dir = app_root.join("config");
+    let display_config_path = config_dir.join("display.ron");
+
+    let game_data = GameDataBuilder::default()
+        .with_bundle(
+            RenderingBundle::<DefaultBackend>::new()
+                .with_plugin(
+                    RenderToWindow::from_config_path(display_config_path)
+                        .with_clear([0.34, 0.36, 0.52, 1.0]),
+                )
+                .with_plugin(RenderFlat2D::default()),
+        )?
+        .with_bundle(TransformBundle::new())?;
+
+    let mut game = Application::new("/", MyState, game_data)?;
+    game.run();
+
+    Ok(())
+}


### PR DESCRIPTION
Follow up of amethyst/amethyst#1806.

# Addition
- A new `0.12.0` template folder

# Modification
- Renamed the `resources` folder of this template to `config`, and renamed the `display_config.ron` inside it,
- Modified the content of `main.rs` to make use of the new `RenderingBundle`.

# Testing performed
- Issued `amethyst new mygame`,
- Ran `cargo run --features "vulkan"` and made sure everything worked as expected.

# Open question
Should this new template create an empty `assets` directory? It seems impossible at the moment.

CC @jojolepro, @torkleyy.