### PR TITLE
Updated `CHANGELOG.md` for 0.9.1 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ adheres to [Semantic Versioning][sv].
 
 [sv]: http://semver.org/
 
+## 0.9.1
+
+* Updated `liquid-value` to allow `amethyst_tools` to build ([#96])
+
+[#96]: https://github.com/amethyst/tools/issues/96
+
 ## 0.7.0
 
 * Complete rewrite of the tool


### PR DESCRIPTION
Trivial: Changelog update.

Can't get https://github.com/amethyst/tools/pull/98 merged because of bors, but for this changelog PR I'll just manually merge after approval.