### PR TITLE
Fix 0.12 template

### DIFF
--- a/templates/0.12.0/index.ron
+++ b/templates/0.12.0/index.ron
@@ -4,4 +4,5 @@
     "main/Cargo.toml.gdpu",
     "main/src/main.rs.gdpu",
     "main/config/display.ron.gdpu",
+    "main/assets/.gitkeep",
 ]

--- a/templates/0.12.0/main/src/main.rs.gdpu
+++ b/templates/0.12.0/main/src/main.rs.gdpu
@@ -1,6 +1,5 @@
 use amethyst::{
     core::transform::TransformBundle,
-    ecs::prelude::{ReadExpect, Resources, SystemData},
     prelude::*,
     renderer::{
         plugins::{RenderFlat2D, RenderToWindow},

--- a/templates/0.12.0/main/src/main.rs.gdpu
+++ b/templates/0.12.0/main/src/main.rs.gdpu
@@ -34,7 +34,7 @@ fn main() -> amethyst::Result<()> {
         )?
         .with_bundle(TransformBundle::new())?;
 
-    let mut game = Application::new("/", MyState, game_data)?;
+    let mut game = Application::new(app_root.join("assets"), MyState, game_data)?;
     game.run();
 
     Ok(())


### PR DESCRIPTION
Fixes warnings about unused imports in the 0.12 template, and changes the asset path to "assets" instead of the root of the project dir. This was originally part of #98 but was moved to a separate pr as requested.