### PR TITLE
Fix clippy lint warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
       install:
         - rustup component add clippy
       script:
-        - cargo clippy --all-targets --all-features --verbose -- -D warnings
+        - cargo clippy --all-targets --all-features --verbose -- -D clippy::pedantic -D warnings
     - stage: coverage
       rust: stable
       script: |

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 use crate::error::*;
 
 const REGISTRY_HOST: &str = "https://crates.io";
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Deserialize)]
 struct Versions {
@@ -33,20 +34,16 @@ pub fn get_latest_version() -> Result<String> {
         .ok_or(ErrorKind::FetchVersionFailure)?
         .version
         .to_string();
-    Ok(dep.to_owned())
+    Ok(dep)
 }
 
 fn fetch_cratesio(path: &str) -> Result<Versions> {
     let url = format!("{host}/api/v1{path}", host = REGISTRY_HOST, path = path);
-    let response = get_with_timeout(&url, get_default_timeout())
+    let response = get_with_timeout(&url, DEFAULT_TIMEOUT)
         .chain_err(|| ErrorKind::FetchVersionFailure)?;
     let version: Versions =
         json::from_reader(response).chain_err(|| ErrorKind::InvalidCratesIoJson)?;
     Ok(version)
-}
-
-fn get_default_timeout() -> Duration {
-    Duration::from_secs(5)
 }
 
 fn get_with_timeout(url: &str, timeout: Duration) -> reqwest::Result<reqwest::Response> {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -39,8 +39,8 @@ pub fn get_latest_version() -> Result<String> {
 
 fn fetch_cratesio(path: &str) -> Result<Versions> {
     let url = format!("{host}/api/v1{path}", host = REGISTRY_HOST, path = path);
-    let response = get_with_timeout(&url, DEFAULT_TIMEOUT)
-        .chain_err(|| ErrorKind::FetchVersionFailure)?;
+    let response =
+        get_with_timeout(&url, DEFAULT_TIMEOUT).chain_err(|| ErrorKind::FetchVersionFailure)?;
     let version: Versions =
         json::from_reader(response).chain_err(|| ErrorKind::InvalidCratesIoJson)?;
     Ok(version)

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ fn exec_new(args: &ArgMatches) {
         .value_of("project_name")
         .expect("Bug: project_name is required");
     let project_name = project_name.to_owned();
-    let version = args.value_of("amethyst_version").map(|v| v.to_owned());
+    let version = args.value_of("amethyst_version").map(ToOwned::to_owned);
 
     let n = cli::New {
         project_name,
@@ -73,7 +73,7 @@ fn exec_new(args: &ArgMatches) {
 
 fn exec_update(args: &ArgMatches) {
     // We don't currently support checking anything other than the version of amethyst tools
-    let _component_name = args.value_of("component_name").map(|c| c.to_owned());
+    let _component_name = args.value_of("component_name").map(ToOwned::to_owned);
     if let Err(e) = check_version() {
         handle_error(&e);
     }

--- a/src/new.rs
+++ b/src/new.rs
@@ -36,7 +36,7 @@ impl New {
             templates::Value::scalar(self.project_name.to_owned()),
         );
 
-        if let Err(err) = templates::deploy("main", &self.version, &path, &params) {
+        if let Err(err) = templates::deploy("main", &self.version, path, &params) {
             remove_dir_all(path).chain_err(|| "could not clean up project folder")?;
             Err(err)
         } else {
@@ -51,8 +51,9 @@ impl New {
 }
 
 impl Default for New {
+    #[must_use]
     fn default() -> Self {
-        New {
+        Self {
             project_name: "game".to_owned(),
             version: None,
         }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -39,9 +39,9 @@ pub fn deploy(
             .to_string(),
     };
 
-    let mut par = params.clone();
-    par.insert("amethyst_version".into(), Value::scalar(version.clone()));
-    let params = &par;
+    let mut params = params.clone();
+    params.insert("amethyst_version".into(), Value::scalar(version.clone()));
+    let params = &params;
 
     let template_files = template_map
         .get::<str>(&version)
@@ -89,7 +89,7 @@ pub fn deploy(
             .join(path)
             .iter()
             .enumerate()
-            .filter_map(|(_, e)| if e != template { Some(e) } else { None })
+            .filter_map(|(_, e)| if e == template { None } else { Some(e) })
             .collect();
 
         create_dir_all(path.parent().expect("Path has no parent"))?;


### PR DESCRIPTION
This fixes all clippy code lints, including `clippy::pedantic` and
`clippy::nursery`.