### PR TITLE
Update templates and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ adheres to [Semantic Versioning][sv].
 
 * Added 0.15.0 template, which chooses a default graphics backend based on the developer's operating system. ([#104])
 
-[#96]: https://github.com/amethyst/tools/pulls/104
+[#104]: https://github.com/amethyst/tools/pull/104
 
 ## 0.9.1
 

--- a/templates/0.13.2/main/Cargo.toml.gdpu
+++ b/templates/0.13.2/main/Cargo.toml.gdpu
@@ -8,6 +8,7 @@ edition = "2018"
 amethyst = "{{ amethyst_version }}"
 
 [features]
+default = ["{{ graphics_backend }}"]
 empty = ["amethyst/empty"]
 metal = ["amethyst/metal"]
 vulkan = ["amethyst/vulkan"]

--- a/templates/0.14.0/main/Cargo.toml.gdpu
+++ b/templates/0.14.0/main/Cargo.toml.gdpu
@@ -8,6 +8,7 @@ edition = "2018"
 amethyst = "{{ amethyst_version }}"
 
 [features]
+default = ["{{ graphics_backend }}"]
 empty = ["amethyst/empty"]
 metal = ["amethyst/metal"]
 vulkan = ["amethyst/vulkan"]


### PR DESCRIPTION
Adds default graphics backend to `0.13.2` and `0.14.0` templates, and fixes a link in the changelog.