### PR TITLE
Re-add support for no_defaults option for default backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ adheres to [Semantic Versioning][sv].
 
 [sv]: http://semver.org/
 
+## 0.10.1
+
+* Update 0.12->0.15 templates to honor no-defaults options in regards of default graphics backend. ([#105])
+
+[#105]: https://github.com/amethyst/tools/pull/110
+
 ## 0.10.0
 
 * Added 0.15.0 template, which chooses a default graphics backend based on the developer's operating system. ([#104])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_tools"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Eyal Kalderon <ebkalderon@gmail.com>"]
 description = "Game development tools for the Amethyst engine"
 keywords = ["game", "engine", "tool", "editor", "amethyst"]

--- a/templates/0.13.2/main/Cargo.toml.gdpu
+++ b/templates/0.13.2/main/Cargo.toml.gdpu
@@ -8,7 +8,19 @@ edition = "2018"
 amethyst = "{{ amethyst_version }}"
 
 [features]
+{%  if graphics_backend -%}
+# This sets default graphics backend for your project, it was automatically detected based
+# on your operating system. It's a great starting point into your journey with amethyst,
+# but if you wish to share this with other people, you may wan to consider removing it
+# and appending `--feature {{ graphics_backend }}` to your commands, letting people on
+# different platforms to chose different ones.
+# Alternatively you can leave the default on, and other users can still disable it by
+# adding `--no-default-features` to their commands, followed by `--feature` of their choice.
+#
+# To read more about it, check out documentation available at:
+# https://book.amethyst.rs/stable/appendices/c_feature_gates.html?highlight=vulkan#graphics-features
 default = ["{{ graphics_backend }}"]
+{% endif -%}
 empty = ["amethyst/empty"]
 metal = ["amethyst/metal"]
 vulkan = ["amethyst/vulkan"]

--- a/templates/0.14.0/main/Cargo.toml.gdpu
+++ b/templates/0.14.0/main/Cargo.toml.gdpu
@@ -8,7 +8,19 @@ edition = "2018"
 amethyst = "{{ amethyst_version }}"
 
 [features]
+{%  if graphics_backend -%}
+# This sets default graphics backend for your project, it was automatically detected based
+# on your operating system. It's a great starting point into your journey with amethyst,
+# but if you wish to share this with other people, you may wan to consider removing it
+# and appending `--feature {{ graphics_backend }}` to your commands, letting people on
+# different platforms to chose different ones.
+# Alternatively you can leave the default on, and other users can still disable it by
+# adding `--no-default-features` to their commands, followed by `--feature` of their choice.
+#
+# To read more about it, check out documentation available at:
+# https://book.amethyst.rs/stable/appendices/c_feature_gates.html?highlight=vulkan#graphics-features
 default = ["{{ graphics_backend }}"]
+{% endif -%}
 empty = ["amethyst/empty"]
 metal = ["amethyst/metal"]
 vulkan = ["amethyst/vulkan"]

--- a/templates/0.15.0/main/Cargo.toml.gdpu
+++ b/templates/0.15.0/main/Cargo.toml.gdpu
@@ -8,7 +8,19 @@ edition = "2018"
 amethyst = "{{ amethyst_version }}"
 
 [features]
+{%  if graphics_backend -%}
+# This sets default graphics backend for your project, it was automatically detected based
+# on your operating system. It's a great starting point into your journey with amethyst,
+# but if you wish to share this with other people, you may wan to consider removing it
+# and appending `--feature {{ graphics_backend }}` to your commands, letting people on
+# different platforms to chose different ones.
+# Alternatively you can leave the default on, and other users can still disable it by
+# adding `--no-default-features` to their commands, followed by `--feature` of their choice.
+#
+# To read more about it, check out documentation available at:
+# https://book.amethyst.rs/stable/appendices/c_feature_gates.html?highlight=vulkan#graphics-features
 default = ["{{ graphics_backend }}"]
+{% endif -%}
 empty = ["amethyst/empty"]
 metal = ["amethyst/metal"]
 vulkan = ["amethyst/vulkan"]


### PR DESCRIPTION
This brings back support for no-defaults across the 0.13-0.15 templates, along with the long explanatory comment, assuming that we still want it.